### PR TITLE
Change type value from any to number

### DIFF
--- a/src/fib.ts
+++ b/src/fib.ts
@@ -1,5 +1,5 @@
 // util function that computes the fibonacci numbers
-export default function fibonacci(n) {
+export default function fibonacci(n : number) : number {
   if (n < 0) {
     return -1;
   } else if (n == 0) {


### PR DESCRIPTION
Fixes fib.ts #1 

Converted argument for fibonacci function from type "any" to type "number" for safe linting.